### PR TITLE
Language detection based on first line

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
                 "icon": {
                     "light": "./resources/doxygen_icon_light.svg",
                     "dark": "./resources/doxygen_icon_dark.svg"
-                }
+                },
+				"firstLine": "# Doxyfile"
             }
         ],
         "grammars": [


### PR DESCRIPTION
Add language detection based on the first line format of the doxyfile template. Tested in doxygen 1.9.1